### PR TITLE
Fix placeholder tool mobile layout

### DIFF
--- a/placeholder-images.html
+++ b/placeholder-images.html
@@ -14,6 +14,10 @@
         .preview img { max-width: 100%; height: auto; border: 1px solid #ccc; }
         .preview .buttons { margin-top: 10px; }
         #urlDisplay { word-break: break-all; margin-top: 10px; font-size: 0.9rem; }
+        @media (max-width: 600px) {
+            .tool-layout { flex-direction: column; }
+            .controls, .preview { max-width: none; width: 100%; }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- make image placeholder tool responsive to smaller screens

## Testing
- `npx htmlhint placeholder-images.html` *(fails: E403 Forbidden)*
- `npx prettier --check placeholder-images.html`

------
https://chatgpt.com/codex/tasks/task_e_684f26229f04832fb5dd93a5ff245082