### PR TITLE
Fix dark theme html tags

### DIFF
--- a/static/codemirror/darcula.css
+++ b/static/codemirror/darcula.css
@@ -22,7 +22,10 @@
 .cm-s-darcula span.cm-link { color: #CC7832; }
 .cm-s-darcula span.cm-atom { color: #CC7832; }
 .cm-s-darcula span.cm-error { color: #BC3F3C; }
-.cm-s-darcula span.cm-tag { color: #629755; font-weight: bold; font-style: italic; text-decoration: underline; }
+.cm-s-darcula span.cm-tag {
+  color: #629755;
+  font-weight: bold;
+}
 .cm-s-darcula span.cm-attribute { color: #6897bb; }
 .cm-s-darcula span.cm-qualifier { color: #6A8759; }
 .cm-s-darcula span.cm-bracket { color: #A9B7C6; }


### PR DESCRIPTION
## Summary
- clean up the Darcula CodeMirror theme so that HTML tags are not italicized or underlined in dark mode

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6adff88832f89b453f2dfd87c99