### PR TITLE
Fix Math Flow tool script

### DIFF
--- a/static/tools_math-flow.js
+++ b/static/tools_math-flow.js
@@ -13,6 +13,8 @@ window.addEventListener('DOMContentLoaded', () => {
     Position
   } = window.ReactFlow;
 
+  const { useCallback } = React;
+
   const initialNodes = [];
   const initialEdges = [];
 
@@ -183,5 +185,10 @@ window.addEventListener('DOMContentLoaded', () => {
     );
   }
 
-  ReactDOM.render(React.createElement(Flow), document.getElementById('root'));
+  const rootEl = document.getElementById('root');
+  if (ReactDOM.createRoot) {
+    ReactDOM.createRoot(rootEl).render(React.createElement(Flow));
+  } else {
+    ReactDOM.render(React.createElement(Flow), rootEl);
+  }
 });


### PR DESCRIPTION
## Summary
- ensure `useCallback` is defined by pulling it from React
- support React 18 by using `createRoot` with a fallback to `ReactDOM.render`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f85451e8832fae984dc6422c2f9c